### PR TITLE
Always load "Plus" as blend method for the atlas

### DIFF
--- a/herbs/layers_control.py
+++ b/herbs/layers_control.py
@@ -348,6 +348,8 @@ class LayersControl(QWidget):
         print(self.layer_link)
         self.layer_opacity.append(100)
         self.layer_blend_mode.append('Plus')
+        self.sig_blend_mode_changed.emit((widget_link, 
+                                          self.layer_blend_mode[-1]))
         self.layer_color.append(color)
         # self.layer_data.append(data)
 


### PR DESCRIPTION
Hi, after using HERBS for some time now, I really thing this is a helpful tool.
One thing I noticed during working with HERBS was that when I load a project with an atlas-overlay or when I first time "Transform to Atlas Slice Window" the composition method (blend mode) is not used but just the image is shown. I then have to change the composition method once to something else then "Plus" and then go back to "Plus" to get the right composition.
This small change in layers_control.py prevents that and makes sure that always the right blend mode is loaded.