### PR TITLE
Remove obj_visibility from object_ctrl and remove check for obj_visibility in herbsgui

### DIFF
--- a/herbs/herbsgui.py
+++ b/herbs/herbsgui.py
@@ -5505,8 +5505,6 @@ class HERBS(QMainWindow, FORM_Main):
             for i in range(len(self.object_ctrl.obj_type)):
                 data_dict = self.object_ctrl.obj_data[i]
                 obj_type = self.object_ctrl.obj_type[i]
-                if not self.object_ctrl.obj_visibility[i]:
-                    self.object_ctrl.obj_list[i].hide()
                 if 'merged' in obj_type:
                     self.object_ctrl.obj_merged.append(obj_type.split(' ')[1])
                     self.add_3d_object(data_dict, obj_type)

--- a/herbs/object_control.py
+++ b/herbs/object_control.py
@@ -732,7 +732,6 @@ class ObjectControl(QObject):
         self.obj_size = []  # size
         self.obj_opacity = []
         self.obj_comp_mode = []
-        self.obj_visibility = []
         self.obj_merged = []
 
         self.probe_icon = QIcon('icons/sidebar/probe.svg')


### PR DESCRIPTION
obj_visibility is not used anymore and the check in load_project in herbsgui produces errors.